### PR TITLE
fix: replace debug_assert with assert for safety-critical checks

### DIFF
--- a/panda-kernel/src/apic/mod.rs
+++ b/panda-kernel/src/apic/mod.rs
@@ -197,7 +197,7 @@ where
 #[inline]
 pub fn eoi() {
     let base = APIC_BASE_VIRT.load(Ordering::Acquire);
-    debug_assert!(base != 0, "Local APIC not initialized");
+    assert!(base != 0, "Local APIC not initialized");
     unsafe {
         let eoi_ptr = (base + reg::EOI as u64) as *mut u32;
         core::ptr::write_volatile(eoi_ptr, 0);

--- a/panda-kernel/src/memory/address.rs
+++ b/panda-kernel/src/memory/address.rs
@@ -95,7 +95,7 @@ pub fn set_heap_phys_base(base: u64) {
 ///   virt = KERNEL_HEAP_BASE + (phys - heap_phys_base)
 pub fn heap_phys_to_virt(phys: PhysAddr) -> VirtAddr {
     let heap_phys_base = HEAP_PHYS_BASE.load(Ordering::Acquire);
-    debug_assert!(
+    assert!(
         phys.as_u64() >= heap_phys_base,
         "physical address {:#x} is below heap base {:#x}",
         phys.as_u64(),


### PR DESCRIPTION
Replace `debug_assert!` with `assert!` for safety-critical bounds checks that must not be stripped in release builds.

Closes #10

Generated with [Claude Code](https://claude.ai/code)