### PR TITLE
security: switch to 64-bit handle IDs with wraparound protection

### DIFF
--- a/panda-abi/src/lib.rs
+++ b/panda-abi/src/lib.rs
@@ -40,33 +40,33 @@ pub struct WellKnownHandle;
 impl WellKnownHandle {
     /// Standard input channel (for pipeline/redirection support).
     /// Handle ID 0 with Channel type tag.
-    pub const STDIN: u32 = HandleType::Channel.make_handle(0);
+    pub const STDIN: u64 = HandleType::Channel.make_handle(0);
 
     /// Standard output channel (for pipeline/redirection support).
     /// Handle ID 1 with Channel type tag.
-    pub const STDOUT: u32 = HandleType::Channel.make_handle(1);
+    pub const STDOUT: u64 = HandleType::Channel.make_handle(1);
 
     /// Standard error channel (reserved for future use).
     /// Handle ID 2 with Channel type tag.
-    pub const STDERR: u32 = HandleType::Channel.make_handle(2);
+    pub const STDERR: u64 = HandleType::Channel.make_handle(2);
 
     /// Handle to the current process (Process resource).
     /// Handle ID 3 with Process type tag.
-    pub const PROCESS: u32 = HandleType::Process.make_handle(3);
+    pub const PROCESS: u64 = HandleType::Process.make_handle(3);
 
     /// Handle to the system environment (Environment resource).
     /// Handle ID 4 - special handle type (no resource backing).
     /// Environment operations don't require a real handle, this is a sentinel.
-    pub const ENVIRONMENT: u32 = 4;
+    pub const ENVIRONMENT: u64 = 4;
 
     /// Handle to the process's default mailbox (Mailbox resource).
     /// Handle ID 5 with Mailbox type tag.
-    pub const MAILBOX: u32 = HandleType::Mailbox.make_handle(5);
+    pub const MAILBOX: u64 = HandleType::Mailbox.make_handle(5);
 
     /// Handle to the channel connected to the parent process (ChannelEndpoint resource).
     /// Handle ID 6 with Channel type tag.
     /// Only valid if this process was spawned by another process.
-    pub const PARENT: u32 = HandleType::Channel.make_handle(6);
+    pub const PARENT: u64 = HandleType::Channel.make_handle(6);
 }
 
 // =============================================================================
@@ -75,8 +75,8 @@ impl WellKnownHandle {
 
 /// Handle type tags encoded in the high 8 bits of a handle value.
 ///
-/// Handle format: `[8 bits: type tag][24 bits: handle id]`
-/// This allows 256 handle types and 16 million handles per process.
+/// Handle format: `[8 bits: type tag][56 bits: handle id]`
+/// This allows 256 handle types and ~72 quadrillion handles per process.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HandleType {
@@ -111,32 +111,32 @@ impl HandleType {
     pub const TAG_BITS: u32 = 8;
 
     /// Number of bits used for the handle ID.
-    pub const ID_BITS: u32 = 24;
+    pub const ID_BITS: u32 = 56;
 
-    /// Mask for extracting the handle ID (low 24 bits).
-    pub const ID_MASK: u32 = (1 << Self::ID_BITS) - 1;
+    /// Mask for extracting the handle ID (low 56 bits).
+    pub const ID_MASK: u64 = (1u64 << Self::ID_BITS) - 1;
 
     /// Mask for extracting the type tag (high 8 bits).
-    pub const TAG_MASK: u32 = 0xFF << Self::ID_BITS;
+    pub const TAG_MASK: u64 = 0xFF << Self::ID_BITS;
 
     /// Maximum handle ID value.
-    pub const MAX_ID: u32 = Self::ID_MASK;
+    pub const MAX_ID: u64 = Self::ID_MASK;
 
     /// Create a tagged handle value from type and ID.
     #[inline]
-    pub const fn make_handle(self, id: u32) -> u32 {
-        ((self as u32) << Self::ID_BITS) | (id & Self::ID_MASK)
+    pub const fn make_handle(self, id: u64) -> u64 {
+        ((self as u64) << Self::ID_BITS) | (id & Self::ID_MASK)
     }
 
     /// Extract the type tag from a handle value.
     #[inline]
-    pub const fn from_handle(handle: u32) -> u8 {
+    pub const fn from_handle(handle: u64) -> u8 {
         (handle >> Self::ID_BITS) as u8
     }
 
     /// Extract the handle ID from a handle value.
     #[inline]
-    pub const fn id_from_handle(handle: u32) -> u32 {
+    pub const fn id_from_handle(handle: u64) -> u64 {
         handle & Self::ID_MASK
     }
 
@@ -173,23 +173,23 @@ impl HandleType {
 
 // Handle constants
 /// Standard input channel handle.
-pub const HANDLE_STDIN: u32 = WellKnownHandle::STDIN;
+pub const HANDLE_STDIN: u64 = WellKnownHandle::STDIN;
 /// Standard output channel handle.
-pub const HANDLE_STDOUT: u32 = WellKnownHandle::STDOUT;
+pub const HANDLE_STDOUT: u64 = WellKnownHandle::STDOUT;
 /// Standard error channel handle (reserved).
-pub const HANDLE_STDERR: u32 = WellKnownHandle::STDERR;
+pub const HANDLE_STDERR: u64 = WellKnownHandle::STDERR;
 /// Handle to the current process (Process resource)
-pub const HANDLE_PROCESS: u32 = WellKnownHandle::PROCESS;
+pub const HANDLE_PROCESS: u64 = WellKnownHandle::PROCESS;
 /// Handle to the system environment (Environment resource)
-pub const HANDLE_ENVIRONMENT: u32 = WellKnownHandle::ENVIRONMENT;
+pub const HANDLE_ENVIRONMENT: u64 = WellKnownHandle::ENVIRONMENT;
 /// Handle to the process's default mailbox (Mailbox resource)
-pub const HANDLE_MAILBOX: u32 = WellKnownHandle::MAILBOX;
+pub const HANDLE_MAILBOX: u64 = WellKnownHandle::MAILBOX;
 /// Handle to the channel connected to the parent process (ChannelEndpoint resource)
-pub const HANDLE_PARENT: u32 = WellKnownHandle::PARENT;
+pub const HANDLE_PARENT: u64 = WellKnownHandle::PARENT;
 
 // Legacy alias for backwards compatibility
 /// Alias for HANDLE_PROCESS (deprecated, use HANDLE_PROCESS instead)
-pub const HANDLE_SELF: u32 = HANDLE_PROCESS;
+pub const HANDLE_SELF: u64 = HANDLE_PROCESS;
 
 // =============================================================================
 // Operation codes
@@ -461,6 +461,21 @@ pub const OP_MAILBOX_CREATE: u32 = Operation::MailboxCreate as u32;
 pub const OP_MAILBOX_WAIT: u32 = Operation::MailboxWait as u32;
 /// Poll for an event on any attached handle (non-blocking): (mailbox) -> (handle, events) or (0, 0)
 pub const OP_MAILBOX_POLL: u32 = Operation::MailboxPoll as u32;
+
+/// Result structure for mailbox wait/poll operations.
+///
+/// Written to userspace via out-pointer. Contains the handle that
+/// generated the event and the event flags.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct MailboxEventResult {
+    /// Handle ID that generated the event.
+    pub handle_id: u64,
+    /// Event flags (see EventFlags).
+    pub events: u32,
+    /// Padding for alignment.
+    pub _pad: u32,
+}
 
 // Channel operations (0x7_1000 - 0x7_1FFF)
 /// Create a channel pair: (out_handles_ptr) -> 0 or error
@@ -774,13 +789,15 @@ pub struct SpawnParams {
     /// Length of the path string.
     pub path_len: usize,
     /// Mailbox handle for event notifications (0 = none).
-    pub mailbox: u32,
+    pub mailbox: u64,
     /// Event mask for mailbox notifications.
     pub event_mask: u32,
+    /// Padding for alignment.
+    pub _pad: u32,
     /// Handle to use for child's stdin (0 = default to parent channel).
-    pub stdin: u32,
+    pub stdin: u64,
     /// Handle to use for child's stdout (0 = default to parent channel).
-    pub stdout: u32,
+    pub stdout: u64,
 }
 
 // =============================================================================
@@ -1159,7 +1176,7 @@ pub struct BlitParams {
     pub y: u32,
     pub width: u32,
     pub height: u32,
-    pub buffer_handle: u32,
+    pub buffer_handle: u64,
 }
 
 /// Parameters for fill operation.

--- a/panda-kernel/src/syscall/buffer.rs
+++ b/panda-kernel/src/syscall/buffer.rs
@@ -59,7 +59,7 @@ pub fn handle_alloc(ua: &UserAccess, size: usize, info_ptr: usize) -> SyscallFut
 /// If info_ptr is non-zero, writes BufferAllocInfo to that address.
 pub fn handle_resize(
     ua: &UserAccess,
-    handle_id: u32,
+    handle_id: u64,
     new_size: usize,
     info_ptr: usize,
 ) -> SyscallFuture {
@@ -159,7 +159,7 @@ pub fn handle_resize(
 }
 
 /// Handle buffer free.
-pub fn handle_free(handle_id: u32) -> SyscallFuture {
+pub fn handle_free(handle_id: u64) -> SyscallFuture {
     let result = scheduler::with_current_process(|proc| {
         // Get buffer's virtual address and size before removing
         let (vaddr, num_pages) = {
@@ -189,7 +189,7 @@ pub fn handle_free(handle_id: u32) -> SyscallFuture {
 
 /// Handle reading from file into buffer.
 /// Returns bytes read on success, negative on error.
-pub fn handle_read_buffer(file_handle_id: u32, buffer_handle_id: u32) -> SyscallFuture {
+pub fn handle_read_buffer(file_handle_id: u64, buffer_handle_id: u64) -> SyscallFuture {
     // Get buffer info (shared buffer pointer and size)
     let (buffer_arc, buffer_size) = match scheduler::with_current_process(|proc| {
         let buffer_handle = proc.handles().get(buffer_handle_id)?;
@@ -246,8 +246,8 @@ pub fn handle_read_buffer(file_handle_id: u32, buffer_handle_id: u32) -> Syscall
 /// Handle writing from buffer to file.
 /// Returns bytes written on success, negative on error.
 pub fn handle_write_buffer(
-    file_handle_id: u32,
-    buffer_handle_id: u32,
+    file_handle_id: u64,
+    buffer_handle_id: u64,
     len: usize,
 ) -> SyscallFuture {
     // Get buffer data (copy to owned Vec since we need it in async block)

--- a/panda-kernel/src/syscall/channel.rs
+++ b/panda-kernel/src/syscall/channel.rs
@@ -20,7 +20,7 @@ use super::user_ptr::{SyscallError, SyscallFuture, SyscallResult, UserAccess, Us
 /// Creates a pair of connected channel endpoints and returns handles to both.
 ///
 /// Arguments:
-/// - out_handles_ptr: Pointer to array of two u32s to receive handle IDs [endpoint_a, endpoint_b]
+/// - out_handles_ptr: Pointer to array of two u64s to receive handle IDs [endpoint_a, endpoint_b]
 ///
 /// Returns 0 on success, negative error code on failure.
 pub fn handle_create(ua: &UserAccess, out_handles_ptr: usize) -> SyscallFuture {
@@ -43,7 +43,7 @@ pub fn handle_create(ua: &UserAccess, out_handles_ptr: usize) -> SyscallFuture {
     });
 
     // Write the handle IDs to userspace
-    let result = ua.write_struct::<[u32; 2]>(out_handles_ptr, &[handle_a, handle_b]);
+    let result = ua.write_struct::<[u64; 2]>(out_handles_ptr, &[handle_a, handle_b]);
 
     let code = match result {
         Ok(_) => {
@@ -61,7 +61,7 @@ pub fn handle_create(ua: &UserAccess, out_handles_ptr: usize) -> SyscallFuture {
 
 /// Get the channel endpoint from a handle, returning a cloned Arc.
 /// This allows us to call methods on the channel outside of with_current_process.
-fn get_channel(handle: u32) -> Option<Arc<dyn Resource>> {
+fn get_channel(handle: u64) -> Option<Arc<dyn Resource>> {
     scheduler::with_current_process(|proc| {
         let h = proc.handles().get(handle)?;
         // Check that it's actually a channel
@@ -85,7 +85,7 @@ fn get_channel(handle: u32) -> Option<Arc<dyn Resource>> {
 /// Returns 0 on success, negative error code on failure.
 pub fn handle_send(
     ua: &UserAccess,
-    handle: u32,
+    handle: u64,
     buf_ptr: usize,
     buf_len: usize,
     flags: usize,
@@ -142,7 +142,7 @@ pub fn handle_send(
 /// - flags: CHANNEL_NONBLOCK to fail instead of blocking if queue empty
 ///
 /// Returns message length on success, negative error code on failure.
-pub fn handle_recv(handle: u32, buf_ptr: usize, buf_len: usize, flags: usize) -> SyscallFuture {
+pub fn handle_recv(handle: u64, buf_ptr: usize, buf_len: usize, flags: usize) -> SyscallFuture {
     let flags = flags as u32;
     let dst = UserSlice::new(buf_ptr, buf_len);
 

--- a/panda-kernel/src/syscall/environment.rs
+++ b/panda-kernel/src/syscall/environment.rs
@@ -32,7 +32,7 @@ pub fn handle_open(
     mailbox_handle: usize,
     event_mask: usize,
 ) -> SyscallFuture {
-    let mailbox_handle = mailbox_handle as u32;
+    let mailbox_handle = mailbox_handle as u64;
     let event_mask = event_mask as u32;
 
     let uri = match ua.read_str(uri_ptr, uri_len) {

--- a/panda-kernel/src/syscall/mod.rs
+++ b/panda-kernel/src/syscall/mod.rs
@@ -124,7 +124,7 @@ extern "sysv64" fn syscall_handler(
         if code != panda_abi::SYSCALL_SEND {
             -1
         } else {
-            let handle = arg0 as u32;
+            let handle = arg0 as u64;
             let operation = arg1 as u32;
 
             // Safety: callee_saved points to registers pushed by syscall_entry
@@ -190,7 +190,7 @@ extern "sysv64" fn syscall_handler(
 /// any future (the compiler enforces this since it is `!Send`).
 fn build_future(
     ua: &user_ptr::UserAccess,
-    handle: u32,
+    handle: u64,
     operation: u32,
     arg0: usize,
     arg1: usize,
@@ -230,8 +230,8 @@ fn build_future(
         OP_BUFFER_FREE => Ok(buffer::handle_free(handle)),
 
         // Buffer-based file operations
-        OP_FILE_READ_BUFFER => Ok(buffer::handle_read_buffer(handle, arg0 as u32)),
-        OP_FILE_WRITE_BUFFER => Ok(buffer::handle_write_buffer(handle, arg0 as u32, arg1)),
+        OP_FILE_READ_BUFFER => Ok(buffer::handle_read_buffer(handle, arg0 as u64)),
+        OP_FILE_WRITE_BUFFER => Ok(buffer::handle_write_buffer(handle, arg0 as u64, arg1)),
 
         // Surface operations
         OP_SURFACE_INFO => Ok(surface::handle_info(ua, handle, arg0)),
@@ -242,8 +242,8 @@ fn build_future(
 
         // Mailbox operations
         OP_MAILBOX_CREATE => Ok(mailbox::handle_create()),
-        OP_MAILBOX_WAIT => Ok(mailbox::handle_wait(handle)),
-        OP_MAILBOX_POLL => Ok(mailbox::handle_poll(handle)),
+        OP_MAILBOX_WAIT => Ok(mailbox::handle_wait(ua, handle, arg0)),
+        OP_MAILBOX_POLL => Ok(mailbox::handle_poll(ua, handle, arg0)),
 
         // Channel operations
         OP_CHANNEL_CREATE => Ok(channel::handle_create(ua, arg0)),

--- a/panda-kernel/src/syscall/process.rs
+++ b/panda-kernel/src/syscall/process.rs
@@ -24,7 +24,7 @@ pub fn handle_get_pid() -> SyscallFuture {
 /// Handle process wait operation.
 ///
 /// Blocks until the target process exits, then returns its exit code.
-pub fn handle_wait(handle_id: u32) -> SyscallFuture {
+pub fn handle_wait(handle_id: u64) -> SyscallFuture {
     let resource = scheduler::with_current_process(|proc| {
         let handle = proc.handles().get(handle_id)?;
         if handle.as_process().is_some() {

--- a/panda-kernel/src/syscall/surface.rs
+++ b/panda-kernel/src/syscall/surface.rs
@@ -29,7 +29,7 @@ fn checked_pixel_buffer_size(width: u32, height: u32) -> Option<usize> {
 /// Returns:
 /// - 0 on success
 /// - negative error code on failure
-pub fn handle_info(ua: &UserAccess, handle: u32, info_ptr: usize) -> SyscallFuture {
+pub fn handle_info(ua: &UserAccess, handle: u64, info_ptr: usize) -> SyscallFuture {
     if info_ptr == 0 {
         return Box::pin(core::future::ready(SyscallResult::err(-1)));
     }
@@ -74,7 +74,7 @@ pub fn handle_info(ua: &UserAccess, handle: u32, info_ptr: usize) -> SyscallFutu
 /// Returns:
 /// - 0 on success
 /// - negative error code on failure
-pub fn handle_blit(ua: &UserAccess, handle: u32, params_ptr: usize) -> SyscallFuture {
+pub fn handle_blit(ua: &UserAccess, handle: u64, params_ptr: usize) -> SyscallFuture {
     if params_ptr == 0 {
         return Box::pin(core::future::ready(SyscallResult::err(-1)));
     }
@@ -235,7 +235,7 @@ pub fn handle_blit(ua: &UserAccess, handle: u32, params_ptr: usize) -> SyscallFu
 /// Returns:
 /// - 0 on success
 /// - negative error code on failure
-pub fn handle_fill(ua: &UserAccess, handle: u32, params_ptr: usize) -> SyscallFuture {
+pub fn handle_fill(ua: &UserAccess, handle: u64, params_ptr: usize) -> SyscallFuture {
     if params_ptr == 0 {
         return Box::pin(core::future::ready(SyscallResult::err(-1)));
     }
@@ -281,7 +281,7 @@ pub fn handle_fill(ua: &UserAccess, handle: u32, params_ptr: usize) -> SyscallFu
 /// Returns:
 /// - 0 on success
 /// - negative error code on failure
-pub fn handle_flush(ua: &UserAccess, handle: u32, rect_ptr: usize) -> SyscallFuture {
+pub fn handle_flush(ua: &UserAccess, handle: u64, rect_ptr: usize) -> SyscallFuture {
     let is_window = scheduler::with_current_process(|proc| {
         let Some(resource) = proc.handles().get(handle) else {
             return None;
@@ -379,7 +379,7 @@ pub fn handle_flush(ua: &UserAccess, handle: u32, rect_ptr: usize) -> SyscallFut
 /// Returns:
 /// - 0 on success
 /// - negative error code on failure
-pub fn handle_update_params(ua: &UserAccess, handle: u32, params_ptr: usize) -> SyscallFuture {
+pub fn handle_update_params(ua: &UserAccess, handle: u64, params_ptr: usize) -> SyscallFuture {
     if params_ptr == 0 {
         return Box::pin(core::future::ready(SyscallResult::err(-1)));
     }

--- a/userspace/libpanda/src/buffer.rs
+++ b/userspace/libpanda/src/buffer.rs
@@ -32,7 +32,7 @@ impl Buffer {
         }
 
         Some(Self {
-            handle: Handle::from(result as u32),
+            handle: Handle::from(result as u64),
             addr: info.addr as *mut u8,
             size: info.size,
         })

--- a/userspace/libpanda/src/environment.rs
+++ b/userspace/libpanda/src/environment.rs
@@ -38,7 +38,7 @@ use panda_abi::*;
 /// ).unwrap();
 /// ```
 #[inline(always)]
-pub fn open(path: &str, mailbox: u32, event_mask: u32) -> Result<Handle> {
+pub fn open(path: &str, mailbox: u64, event_mask: u32) -> Result<Handle> {
     error::from_syscall_handle(sys::env::open(path, mailbox, event_mask))
 }
 

--- a/userspace/libpanda/src/error.rs
+++ b/userspace/libpanda/src/error.rs
@@ -152,6 +152,6 @@ pub fn from_syscall_handle(result: isize) -> Result<crate::Handle> {
     if result < 0 {
         Err(Error::from_code(result))
     } else {
-        Ok(crate::Handle::from(result as u32))
+        Ok(crate::Handle::from(result as u64))
     }
 }

--- a/userspace/libpanda/src/graphics/pixels.rs
+++ b/userspace/libpanda/src/graphics/pixels.rs
@@ -41,7 +41,7 @@ impl PixelBuffer {
         }
 
         Ok(Self {
-            handle: Handle::from(result as u32),
+            handle: Handle::from(result as u64),
             ptr: info.addr as *mut u32,
             width,
             height,

--- a/userspace/libpanda/src/graphics/surface.rs
+++ b/userspace/libpanda/src/graphics/surface.rs
@@ -40,7 +40,7 @@ impl Surface {
             Err(Error::from_code(result))
         } else {
             Ok(Self {
-                handle: Handle::from(result as u32),
+                handle: Handle::from(result as u64),
             })
         }
     }

--- a/userspace/libpanda/src/handle.rs
+++ b/userspace/libpanda/src/handle.rs
@@ -17,19 +17,19 @@ use core::marker::PhantomData;
 /// For type-safe handles, see `TypedHandle<T>`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
-pub struct Handle(u32);
+pub struct Handle(u64);
 
 impl Handle {
     /// Create a handle from a raw handle ID.
     ///
     /// # Safety
     /// The caller must ensure the handle ID is valid for the current process.
-    pub const unsafe fn from_raw(id: u32) -> Self {
+    pub const unsafe fn from_raw(id: u64) -> Self {
         Handle(id)
     }
 
     /// Get the raw handle ID.
-    pub const fn as_raw(self) -> u32 {
+    pub const fn as_raw(self) -> u64 {
         self.0
     }
 
@@ -72,14 +72,14 @@ impl Handle {
     }
 }
 
-impl From<Handle> for u32 {
-    fn from(handle: Handle) -> u32 {
+impl From<Handle> for u64 {
+    fn from(handle: Handle) -> u64 {
         handle.0
     }
 }
 
-impl From<u32> for Handle {
-    fn from(id: u32) -> Handle {
+impl From<u64> for Handle {
+    fn from(id: u64) -> Handle {
         Handle(id)
     }
 }
@@ -104,7 +104,7 @@ pub trait HandleKind: private::Sealed {
     const EXPECTED_TYPE: panda_abi::HandleType;
 
     /// Check if a raw handle value has a compatible type tag.
-    fn is_compatible(handle: u32) -> bool {
+    fn is_compatible(handle: u64) -> bool {
         let tag = panda_abi::HandleType::from_handle(handle);
         if let Some(actual_type) = panda_abi::HandleType::from_tag(tag) {
             actual_type.is_compatible_with(Self::EXPECTED_TYPE)
@@ -132,7 +132,7 @@ pub trait HandleKind: private::Sealed {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct TypedHandle<T: HandleKind> {
-    id: u32,
+    id: u64,
     _marker: PhantomData<T>,
 }
 
@@ -142,7 +142,7 @@ impl<T: HandleKind> TypedHandle<T> {
     /// # Safety
     /// The caller must ensure the handle ID refers to a resource of type `T`.
     #[inline]
-    pub const unsafe fn from_raw_unchecked(id: u32) -> Self {
+    pub const unsafe fn from_raw_unchecked(id: u64) -> Self {
         Self {
             id,
             _marker: PhantomData,
@@ -153,7 +153,7 @@ impl<T: HandleKind> TypedHandle<T> {
     ///
     /// Returns `None` if the handle's type tag doesn't match the expected type.
     #[inline]
-    pub fn from_raw(id: u32) -> Option<Self> {
+    pub fn from_raw(id: u64) -> Option<Self> {
         if T::is_compatible(id) {
             Some(Self {
                 id,
@@ -169,13 +169,13 @@ impl<T: HandleKind> TypedHandle<T> {
     /// # Panics
     /// Panics if the handle's type tag doesn't match the expected type.
     #[inline]
-    pub fn from_raw_or_panic(id: u32) -> Self {
+    pub fn from_raw_or_panic(id: u64) -> Self {
         Self::from_raw(id).expect("handle type mismatch")
     }
 
     /// Get the raw handle ID.
     #[inline]
-    pub const fn as_raw(&self) -> u32 {
+    pub const fn as_raw(&self) -> u64 {
         self.id
     }
 
@@ -220,8 +220,8 @@ impl<T: HandleKind> From<TypedHandle<T>> for Handle {
     }
 }
 
-impl<T: HandleKind> From<TypedHandle<T>> for u32 {
-    fn from(typed: TypedHandle<T>) -> u32 {
+impl<T: HandleKind> From<TypedHandle<T>> for u64 {
+    fn from(typed: TypedHandle<T>) -> u64 {
         typed.id
     }
 }

--- a/userspace/libpanda/src/io/file.rs
+++ b/userspace/libpanda/src/io/file.rs
@@ -41,7 +41,7 @@ impl File {
         if result < 0 {
             Err(Error::from_code(result))
         } else {
-            let handle = FileHandle::from_raw(result as u32).ok_or(Error::InvalidArgument)?;
+            let handle = FileHandle::from_raw(result as u64).ok_or(Error::InvalidArgument)?;
             Ok(Self { handle })
         }
     }
@@ -60,12 +60,12 @@ impl File {
     ///     panda_abi::EVENT_KEYBOARD_KEY,
     /// ).unwrap();
     /// ```
-    pub fn open_with_mailbox(path: &str, mailbox: u32, event_mask: u32) -> Result<Self> {
+    pub fn open_with_mailbox(path: &str, mailbox: u64, event_mask: u32) -> Result<Self> {
         let result = sys::env::open(path, mailbox, event_mask);
         if result < 0 {
             Err(Error::from_code(result))
         } else {
-            let handle = FileHandle::from_raw(result as u32).ok_or(Error::InvalidArgument)?;
+            let handle = FileHandle::from_raw(result as u64).ok_or(Error::InvalidArgument)?;
             Ok(Self { handle })
         }
     }

--- a/userspace/libpanda/src/ipc/channel.rs
+++ b/userspace/libpanda/src/ipc/channel.rs
@@ -233,13 +233,12 @@ pub fn try_recv(handle: Handle, buf: &mut [u8]) -> Result<usize> {
 /// Returns handles to both endpoints: `(endpoint_a, endpoint_b)`.
 /// Messages sent on endpoint_a are received by endpoint_b, and vice versa.
 pub fn create_pair() -> Result<(ChannelHandle, ChannelHandle)> {
-    let result = sys::channel::create_raw();
+    let mut handles: [u64; 2] = [0, 0];
+    let result = sys::channel::create_raw(&mut handles);
     if result < 0 {
         return Err(Error::from_code(result));
     }
-    // Result encodes both handles: high 32 bits = handle_a, low 32 bits = handle_b
-    let handle_a = ChannelHandle::from_raw((result >> 32) as u32).ok_or(Error::InvalidArgument)?;
-    let handle_b =
-        ChannelHandle::from_raw((result & 0xFFFFFFFF) as u32).ok_or(Error::InvalidArgument)?;
+    let handle_a = ChannelHandle::from_raw(handles[0]).ok_or(Error::InvalidArgument)?;
+    let handle_b = ChannelHandle::from_raw(handles[1]).ok_or(Error::InvalidArgument)?;
     Ok((handle_a, handle_b))
 }

--- a/userspace/libpanda/src/process/child.rs
+++ b/userspace/libpanda/src/process/child.rs
@@ -248,7 +248,7 @@ impl<'a> ChildBuilder<'a> {
             return Err(Error::from_code(result));
         }
 
-        let handle = Handle::from(result as u32);
+        let handle = Handle::from(result as u64);
 
         // Build environment: start with inherited if enabled, then add explicit vars
         // We use owned strings to avoid lifetime issues with inherited env

--- a/userspace/libpanda/src/sys/buffer.rs
+++ b/userspace/libpanda/src/sys/buffer.rs
@@ -48,7 +48,7 @@ pub fn read_from_file(file_handle: Handle, buffer_handle: Handle) -> isize {
     send(
         file_handle,
         OP_FILE_READ_BUFFER,
-        u32::from(buffer_handle) as usize,
+        u64::from(buffer_handle) as usize,
         0,
         0,
         0,
@@ -63,7 +63,7 @@ pub fn write_to_file(file_handle: Handle, buffer_handle: Handle, len: usize) -> 
     send(
         file_handle,
         OP_FILE_WRITE_BUFFER,
-        u32::from(buffer_handle) as usize,
+        u64::from(buffer_handle) as usize,
         len,
         0,
         0,

--- a/userspace/libpanda/src/sys/channel.rs
+++ b/userspace/libpanda/src/sys/channel.rs
@@ -8,31 +8,23 @@ use panda_abi::*;
 
 /// Create a channel pair (raw syscall).
 ///
-/// On success, returns a positive value encoding both handles:
-/// - High 32 bits: handle_a
-/// - Low 32 bits: handle_b
+/// On success, writes two u64 handle IDs to the `handles` output parameter
+/// and returns 0.
 ///
 /// On failure, returns a negative error code.
 ///
 /// Note: This is the raw syscall. Use `crate::ipc::channel::create_pair()` for
-/// a safer interface that returns `Result<(Handle, Handle)>`.
+/// a safer interface that returns `Result<(ChannelHandle, ChannelHandle)>`.
 #[inline(always)]
-pub fn create_raw() -> isize {
-    let mut handles: [u32; 2] = [0, 0];
-    let result = send(
-        Handle::from(0u32), // No source handle for create
+pub fn create_raw(handles: &mut [u64; 2]) -> isize {
+    send(
+        Handle::from(0u64), // No source handle for create
         OP_CHANNEL_CREATE,
         handles.as_mut_ptr() as usize,
         0,
         0,
         0,
-    );
-    if result < 0 {
-        result
-    } else {
-        // Pack both handles into a single isize for the caller to unpack
-        ((handles[0] as isize) << 32) | (handles[1] as isize)
-    }
+    )
 }
 
 /// Send a message on a channel (blocking if queue full).

--- a/userspace/libpanda/src/sys/env.rs
+++ b/userspace/libpanda/src/sys/env.rs
@@ -13,7 +13,7 @@ use panda_abi::*;
 /// To attach the handle to a mailbox for event notifications, pass the
 /// mailbox handle and event mask. Pass `(0, 0)` for no mailbox attachment.
 #[inline(always)]
-pub fn open(path: &str, mailbox: u32, event_mask: u32) -> isize {
+pub fn open(path: &str, mailbox: u64, event_mask: u32) -> isize {
     send(
         Handle::ENVIRONMENT,
         OP_ENVIRONMENT_OPEN,
@@ -37,12 +37,13 @@ pub fn open(path: &str, mailbox: u32, event_mask: u32) -> isize {
 /// Note: This is the raw spawn syscall. Use `crate::environment::spawn` for
 /// the higher-level version that also sends startup arguments.
 #[inline(always)]
-pub fn spawn(path: &str, mailbox: u32, event_mask: u32, stdin: u32, stdout: u32) -> isize {
+pub fn spawn(path: &str, mailbox: u64, event_mask: u32, stdin: u64, stdout: u64) -> isize {
     let params = SpawnParams {
         path_ptr: path.as_ptr() as usize,
         path_len: path.len(),
         mailbox,
         event_mask,
+        _pad: 0,
         stdin,
         stdout,
     };

--- a/userspace/libpanda/src/sys/mailbox.rs
+++ b/userspace/libpanda/src/sys/mailbox.rs
@@ -12,7 +12,7 @@ use panda_abi::*;
 #[inline(always)]
 pub fn create() -> isize {
     send(
-        Handle::from(0), // handle arg unused for create
+        Handle::from(0u64), // handle arg unused for create
         OP_MAILBOX_CREATE,
         0,
         0,
@@ -23,24 +23,32 @@ pub fn create() -> isize {
 
 /// Wait for an event on a mailbox (blocking).
 ///
-/// Returns packed result: `(handle_id << 32) | event_flags`.
+/// Writes the result to the provided `MailboxEventResult` struct.
+/// Returns 0 on success, negative error code on failure.
 #[inline(always)]
-pub fn wait(mailbox: Handle) -> isize {
-    send(mailbox, OP_MAILBOX_WAIT, 0, 0, 0, 0)
+pub fn wait(mailbox: Handle, result: &mut MailboxEventResult) -> isize {
+    send(
+        mailbox,
+        OP_MAILBOX_WAIT,
+        result as *mut MailboxEventResult as usize,
+        0,
+        0,
+        0,
+    )
 }
 
 /// Poll for an event on a mailbox (non-blocking).
 ///
-/// Returns packed result: `(handle_id << 32) | event_flags`, or 0 if no events.
+/// Writes the result to the provided `MailboxEventResult` struct.
+/// Returns 1 if an event was available, 0 if no events, negative on error.
 #[inline(always)]
-pub fn poll(mailbox: Handle) -> isize {
-    send(mailbox, OP_MAILBOX_POLL, 0, 0, 0, 0)
-}
-
-/// Unpack a mailbox result into (handle_id, event_flags).
-#[inline(always)]
-pub fn unpack_result(result: isize) -> (u32, u32) {
-    let handle_id = (result >> 32) as u32;
-    let events = result as u32;
-    (handle_id, events)
+pub fn poll(mailbox: Handle, result: &mut MailboxEventResult) -> isize {
+    send(
+        mailbox,
+        OP_MAILBOX_POLL,
+        result as *mut MailboxEventResult as usize,
+        0,
+        0,
+        0,
+    )
 }

--- a/userspace/libpanda/src/sys/mod.rs
+++ b/userspace/libpanda/src/sys/mod.rs
@@ -119,7 +119,7 @@ pub fn send(
 ) -> isize {
     syscall(
         SYSCALL_SEND,
-        u32::from(handle) as usize,
+        u64::from(handle) as usize,
         operation as usize,
         arg0,
         arg1,

--- a/userspace/libpanda/src/syscall.rs
+++ b/userspace/libpanda/src/syscall.rs
@@ -59,7 +59,7 @@ pub fn send(
 ) -> isize {
     syscall(
         SYSCALL_SEND,
-        u32::from(handle) as usize,
+        u64::from(handle) as usize,
         operation as usize,
         arg0,
         arg1,

--- a/userspace/tests/error_test/src/main.rs
+++ b/userspace/tests/error_test/src/main.rs
@@ -26,7 +26,7 @@ libpanda::main! {
     // Test 2: Channel operations on invalid handle
     environment::log("Test 2: Channel operations on invalid handle");
 
-    let invalid_handle = Handle::from(0xDEAD);
+    let invalid_handle = Handle::from(0xDEADu64);
 
     match ipc::try_send(invalid_handle, b"test") {
         Ok(_) => {


### PR DESCRIPTION
Widen all handle types from u32 (8-bit tag + 24-bit ID) to u64 (8-bit tag + 56-bit ID), preventing handle ID exhaustion and eliminating the risk of handle aliasing after ~16M allocations.

Closes #9 (handle exhaustion component)

Generated with [Claude Code](https://claude.ai/code)