### PR TITLE
feat: Implement signal support (OP_PROCESS_SIGNAL)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal_child"
+version = "0.1.0"
+dependencies = [
+ "libpanda",
+ "panda-abi",
+]
+
+[[package]]
+name = "signal_test"
+version = "0.1.0"
+dependencies = [
+ "libpanda",
+ "panda-abi",
+]
+
+[[package]]
 name = "size_cap_test"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ members = [
   "userspace/tests/fault_child",
   "userspace/tests/fmask_test",
   "userspace/tests/handle_limit_test",
+  "userspace/tests/signal_test",
+  "userspace/tests/signal_child",
   "crates/ring-buffer",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ KERNEL_TESTS := \
 	raii \
 	resource \
 	scheduler \
+	signal \
 	smap \
 	vfs_path
 
@@ -64,6 +65,7 @@ USERSPACE_TESTS := \
 	readdir_test \
 	resource_test \
 	segfault_test \
+	signal_test \
 	size_cap_test \
 	spawn_test \
 	state_test \
@@ -89,7 +91,8 @@ pipeline_test_EXTRAS := pipeline_producer pipeline_consumer
 control_plane_test_EXTRAS := control_plane_child
 env_test_EXTRAS := env_child
 fault_recovery_test_EXTRAS := fault_child
-export spawn_test_EXTRAS yield_test_EXTRAS preempt_test_EXTRAS channel_test_EXTRAS mailbox_test_EXTRAS mailbox_overflow_test_EXTRAS args_test_EXTRAS pipeline_test_EXTRAS control_plane_test_EXTRAS env_test_EXTRAS fault_recovery_test_EXTRAS
+signal_test_EXTRAS := signal_child
+export spawn_test_EXTRAS yield_test_EXTRAS preempt_test_EXTRAS channel_test_EXTRAS mailbox_test_EXTRAS mailbox_overflow_test_EXTRAS args_test_EXTRAS pipeline_test_EXTRAS control_plane_test_EXTRAS env_test_EXTRAS fault_recovery_test_EXTRAS signal_test_EXTRAS
 export PROFILE_DIR CARGO_PROFILE
 
 # Cargo commands for custom targets (require build-std for no_std targets)

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -121,6 +121,105 @@ EVENT_KEYBOARD_KEY      // Key event available
 EVENT_PROCESS_EXITED    // Child process exited
 ```
 
+**Signal events:**
+```rust
+EVENT_SIGNAL_RECEIVED   // Signal message available
+```
+
+## Signals
+
+Signals provide a mechanism for process termination and notification.
+
+### Signal types
+
+| Signal | Value | Behaviour |
+|--------|-------|-----------|
+| `Signal::Terminate` | 0 | Graceful termination request. Delivered as a message on `HANDLE_PARENT`. |
+| `Signal::Kill` | 1 | Forced termination. Kernel immediately tears down the process. |
+
+### SIGKILL semantics
+
+When a process receives `Signal::Kill`:
+1. Kernel immediately removes it from the scheduler
+2. All handles are closed (channels notify peers)
+3. Memory is reclaimed
+4. Exit code is set to -9
+5. Waiters are woken with the exit code
+
+### SIGTERM semantics
+
+When a process receives `Signal::Terminate`:
+1. A `ProcessSignalRequest` message is sent via the parent-child channel
+2. `EVENT_SIGNAL_RECEIVED` and `EVENT_CHANNEL_READABLE` are posted to the child's mailbox
+3. The child receives the message on `HANDLE_PARENT`
+4. The message uses `MessageHeader` with `msg_type = ProcessMessageType::Signal`
+5. The process can catch and handle it gracefully
+6. If the channel is full, the syscall returns `WouldBlock`
+
+### Signal message format
+
+Signals use the existing message infrastructure with safe encoding/decoding:
+
+```rust
+// MessageHeader (16 bytes)
+// - id: u64 = 0 (unsolicited event)
+// - msg_type: u32 = ProcessMessageType::Signal
+// - _reserved: u32 = 0
+// Signal payload (8 bytes)
+// - signal: u32 = Signal value
+// - _pad: u32 = 0
+
+// Total: 24 bytes (SIGNAL_MESSAGE_SIZE)
+```
+
+### API
+
+```rust
+use libpanda::process::{Child, Signal};
+
+// Spawn a child
+let mut child = Child::spawn("file:/initrd/program")?;
+
+// Send SIGTERM (graceful termination)
+child.signal(Signal::Term)?;
+
+// Send SIGKILL (forced termination)
+child.kill()?;  // Shorthand for signal(Signal::Kill)
+
+// Wait for exit
+let status = child.wait()?;
+```
+
+### Handling signals (child side)
+
+```rust
+use panda_abi::{EventFlags, SignalMessage, Signal, SIGNAL_MESSAGE_SIZE, WellKnownHandle};
+
+libpanda::main! {
+    let mailbox = Mailbox::default();
+
+    loop {
+        let (handle, events) = mailbox.wait();
+        let events = EventFlags(events);
+
+        if handle == WellKnownHandle::PARENT && events.is_signal_received() {
+            let mut buf = [0u8; SIGNAL_MESSAGE_SIZE];
+            if let Ok(len) = channel::try_recv(HANDLE_PARENT, &mut buf) {
+                if let Ok(Some(msg)) = SignalMessage::decode(&buf[..len]) {
+                    match msg.signal {
+                        Signal::Terminate => {
+                            // Handle graceful shutdown
+                            return 0;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
 ## Well-Known Handles
 
 Every process has these pre-allocated handles. Handle values encode a type tag in the high 8 bits and an ID in the low 24 bits.

--- a/panda-abi/src/encoding.rs
+++ b/panda-abi/src/encoding.rs
@@ -113,6 +113,11 @@ impl Encoder {
         self.buf.extend_from_slice(&value.to_le_bytes());
     }
 
+    /// Write a u64 (little-endian).
+    pub fn write_u64(&mut self, value: u64) {
+        self.buf.extend_from_slice(&value.to_le_bytes());
+    }
+
     /// Write an i64 (little-endian).
     pub fn write_i64(&mut self, value: i64) {
         self.buf.extend_from_slice(&value.to_le_bytes());
@@ -241,6 +246,25 @@ impl<'a> Decoder<'a> {
             self.buf[self.pos + 3],
         ]);
         self.pos += 4;
+        Ok(value)
+    }
+
+    /// Read a u64 (little-endian).
+    pub fn read_u64(&mut self) -> Result<u64, DecodeError> {
+        if self.remaining() < 8 {
+            return Err(DecodeError::Truncated);
+        }
+        let value = u64::from_le_bytes([
+            self.buf[self.pos],
+            self.buf[self.pos + 1],
+            self.buf[self.pos + 2],
+            self.buf[self.pos + 3],
+            self.buf[self.pos + 4],
+            self.buf[self.pos + 5],
+            self.buf[self.pos + 6],
+            self.buf[self.pos + 7],
+        ]);
+        self.pos += 8;
         Ok(value)
     }
 
@@ -402,6 +426,18 @@ impl Encode for i32 {
 impl Decode for i32 {
     fn decode(dec: &mut Decoder) -> Result<Self, DecodeError> {
         dec.read_i32()
+    }
+}
+
+impl Encode for u64 {
+    fn encode(&self, enc: &mut Encoder) {
+        enc.write_u64(*self);
+    }
+}
+
+impl Decode for u64 {
+    fn decode(dec: &mut Decoder) -> Result<Self, DecodeError> {
+        dec.read_u64()
     }
 }
 

--- a/panda-abi/src/lib.rs
+++ b/panda-abi/src/lib.rs
@@ -1312,6 +1312,16 @@ impl Signal {
     pub const fn as_u32(self) -> u32 {
         self as u32
     }
+
+    /// Get the exit code that should be set when a process is terminated by this signal.
+    ///
+    /// Returns `None` for signals that don't cause immediate termination.
+    pub const fn exit_code(self) -> Option<i32> {
+        match self {
+            Signal::Stop => None, // Graceful, no exit code
+            Signal::StopImmediately => Some(EXIT_STOP_IMMEDIATELY),
+        }
+    }
 }
 
 impl encoding::Encode for Signal {

--- a/panda-abi/src/lib.rs
+++ b/panda-abi/src/lib.rs
@@ -1274,6 +1274,14 @@ pub struct ProcessSignalResponse {
     pub _pad: u32,
 }
 
+// =============================================================================
+// Exit codes
+// =============================================================================
+
+/// Exit code for processes terminated by `Signal::StopImmediately`.
+/// This is an immediate forced termination where no userspace code runs.
+pub const EXIT_STOP_IMMEDIATELY: i32 = -9;
+
 /// Signals that can be sent to a process via OP_PROCESS_SIGNAL.
 ///
 /// Signals provide a mechanism for process termination and notification:

--- a/panda-kernel/Cargo.toml
+++ b/panda-kernel/Cargo.toml
@@ -107,3 +107,7 @@ harness = false
 [[test]]
 name = "mailbox"
 harness = false
+
+[[test]]
+name = "signal"
+harness = false

--- a/panda-kernel/src/resource/mod.rs
+++ b/panda-kernel/src/resource/mod.rs
@@ -26,7 +26,7 @@ pub use char_output::{CharOutError, CharacterOutput};
 pub use directory::{DirEntry, Directory};
 pub use event_source::{Event, EventSource, KeyEvent};
 pub use mailbox::{Mailbox, MailboxRef};
-pub use process::Process as ProcessInterface;
+pub use process::{Process as ProcessInterface, ProcessError};
 pub use process_resource::ProcessResource;
 pub use scheme::{
     ConsoleScheme, DirectoryResource, FileScheme, KeyboardResource, KeyboardScheme, SchemeHandler,

--- a/panda-kernel/src/resource/process.rs
+++ b/panda-kernel/src/resource/process.rs
@@ -36,4 +36,6 @@ pub enum ProcessError {
     NotFound,
     /// Permission denied.
     PermissionDenied,
+    /// Operation would block.
+    WouldBlock,
 }

--- a/panda-kernel/src/resource/spawn_handle.rs
+++ b/panda-kernel/src/resource/spawn_handle.rs
@@ -98,7 +98,7 @@ impl Process for SpawnHandle {
         let signal = panda_abi::Signal::from_u32(signal).ok_or(ProcessError::NotSupported)?;
 
         match signal {
-            panda_abi::Signal::Kill => {
+            panda_abi::Signal::StopImmediately => {
                 // SIGKILL: Immediate forced termination
                 let pid = self.process_info.pid();
 
@@ -116,7 +116,7 @@ impl Process for SpawnHandle {
 
                 Ok(())
             }
-            panda_abi::Signal::Terminate => {
+            panda_abi::Signal::Stop => {
                 // SIGTERM: Deliver message to process's parent channel
                 // The child process reads from HANDLE_PARENT and handles it
 

--- a/panda-kernel/src/resource/spawn_handle.rs
+++ b/panda-kernel/src/resource/spawn_handle.rs
@@ -7,8 +7,10 @@ use alloc::sync::Arc;
 use crate::process::ProcessId;
 use crate::process::info::ProcessInfo;
 use crate::process::waker::Waker;
+use crate::resource::channel::ChannelError;
 use crate::resource::process::{Process, ProcessError};
 use crate::resource::{ChannelEndpoint, MailboxRef, Resource};
+use crate::scheduler;
 
 /// A handle returned from spawn() that combines channel and process info.
 ///
@@ -92,9 +94,57 @@ impl Process for SpawnHandle {
         self.process_info.exit_code()
     }
 
-    fn signal(&self, _signal: u32) -> Result<(), ProcessError> {
-        // TODO: Implement signal delivery
-        Err(ProcessError::NotSupported)
+    fn signal(&self, signal: u32) -> Result<(), ProcessError> {
+        let signal = panda_abi::Signal::from_u32(signal).ok_or(ProcessError::NotSupported)?;
+
+        match signal {
+            panda_abi::Signal::Kill => {
+                // SIGKILL: Immediate forced termination
+                let pid = self.process_info.pid();
+
+                // Check if already exited
+                if self.process_info.has_exited() {
+                    return Ok(());
+                }
+
+                // Set exit code before removal so waiters see it
+                // Convention: -9 is the SIGKILL exit code
+                self.process_info.set_exit_code(-9);
+
+                // Remove from scheduler (reclaims memory, closes handles)
+                scheduler::remove_process(pid);
+
+                Ok(())
+            }
+            panda_abi::Signal::Terminate => {
+                // SIGTERM: Deliver message to process's parent channel
+                // The child process reads from HANDLE_PARENT and handles it
+
+                // Check if already exited
+                if self.process_info.has_exited() {
+                    return Err(ProcessError::NotFound);
+                }
+
+                // Build signal message using safe encoding
+                let mut buf = [0u8; panda_abi::SIGNAL_MESSAGE_SIZE];
+                let len = panda_abi::encode_signal_message(signal, &mut buf)
+                    .ok_or(ProcessError::NotSupported)?;
+
+                // Send via channel with SIGNAL_RECEIVED event
+                // (also includes CHANNEL_READABLE so the child can recv the message)
+                let event_flags =
+                    panda_abi::EVENT_SIGNAL_RECEIVED | panda_abi::EVENT_CHANNEL_READABLE;
+                self.channel
+                    .send_with_event(&buf[..len], event_flags)
+                    .map_err(|e| match e {
+                        ChannelError::QueueFull => ProcessError::WouldBlock,
+                        ChannelError::PeerClosed => ProcessError::NotFound,
+                        _ => ProcessError::NotSupported,
+                    })?;
+
+                Ok(())
+            }
+        }
     }
 
     fn waker(&self) -> Arc<Waker> {

--- a/panda-kernel/src/resource/spawn_handle.rs
+++ b/panda-kernel/src/resource/spawn_handle.rs
@@ -99,7 +99,7 @@ impl Process for SpawnHandle {
 
         match signal {
             panda_abi::Signal::StopImmediately => {
-                // SIGKILL: Immediate forced termination
+                // Immediate forced termination - no userspace code runs
                 let pid = self.process_info.pid();
 
                 // Check if already exited
@@ -108,8 +108,7 @@ impl Process for SpawnHandle {
                 }
 
                 // Set exit code before removal so waiters see it
-                // Convention: -9 is the SIGKILL exit code
-                self.process_info.set_exit_code(-9);
+                self.process_info.set_exit_code(panda_abi::EXIT_STOP_IMMEDIATELY);
 
                 // Remove from scheduler (reclaims memory, closes handles)
                 scheduler::remove_process(pid);
@@ -117,7 +116,7 @@ impl Process for SpawnHandle {
                 Ok(())
             }
             panda_abi::Signal::Stop => {
-                // SIGTERM: Deliver message to process's parent channel
+                // Deliver message to process's parent channel
                 // The child process reads from HANDLE_PARENT and handles it
 
                 // Check if already exited

--- a/panda-kernel/src/syscall/mod.rs
+++ b/panda-kernel/src/syscall/mod.rs
@@ -214,7 +214,7 @@ fn build_future(
         // Process operations (yield and exit are handled above as diverging)
         OP_PROCESS_GET_PID => Ok(process::handle_get_pid()),
         OP_PROCESS_WAIT => Ok(process::handle_wait(handle)),
-        OP_PROCESS_SIGNAL => Ok(process::handle_signal()),
+        OP_PROCESS_SIGNAL => Ok(process::handle_signal(handle, arg0 as u32)),
         OP_PROCESS_BRK => Ok(process::handle_brk(arg0)),
 
         // Environment operations

--- a/panda-kernel/src/syscall/process.rs
+++ b/panda-kernel/src/syscall/process.rs
@@ -58,8 +58,8 @@ pub fn handle_wait(handle_id: u64) -> SyscallFuture {
 /// Handle process signal operation.
 ///
 /// Sends a signal to the target process:
-/// - `Signal::Kill`: Immediately terminates the process (SIGKILL-like)
-/// - `Signal::Terminate`: Delivers a message to the process's parent channel (SIGTERM-like)
+/// - `Signal::StopImmediately`: Immediately terminates the process (SIGKILL-like)
+/// - `Signal::Stop`: Delivers a message to the process's parent channel (SIGTERM-like)
 pub fn handle_signal(handle_id: u64, signal: u32) -> SyscallFuture {
     // 1. Validate signal number
     let signal = match panda_abi::Signal::from_u32(signal) {

--- a/panda-kernel/src/syscall/process.rs
+++ b/panda-kernel/src/syscall/process.rs
@@ -58,8 +58,8 @@ pub fn handle_wait(handle_id: u64) -> SyscallFuture {
 /// Handle process signal operation.
 ///
 /// Sends a signal to the target process:
-/// - `Signal::StopImmediately`: Immediately terminates the process (SIGKILL-like)
-/// - `Signal::Stop`: Delivers a message to the process's parent channel (SIGTERM-like)
+/// - `Signal::StopImmediately`: Immediately terminates the process (no userspace code runs)
+/// - `Signal::Stop`: Delivers a message to the process's parent channel for graceful handling
 pub fn handle_signal(handle_id: u64, signal: u32) -> SyscallFuture {
     // 1. Validate signal number
     let signal = match panda_abi::Signal::from_u32(signal) {

--- a/panda-kernel/src/syscall/process.rs
+++ b/panda-kernel/src/syscall/process.rs
@@ -56,10 +56,59 @@ pub fn handle_wait(handle_id: u64) -> SyscallFuture {
 }
 
 /// Handle process signal operation.
-pub fn handle_signal() -> SyscallFuture {
-    Box::pin(core::future::ready(SyscallResult::err(
-        panda_abi::ErrorCode::NotSupported,
-    )))
+///
+/// Sends a signal to the target process:
+/// - `Signal::Kill`: Immediately terminates the process (SIGKILL-like)
+/// - `Signal::Terminate`: Delivers a message to the process's parent channel (SIGTERM-like)
+pub fn handle_signal(handle_id: u64, signal: u32) -> SyscallFuture {
+    // 1. Validate signal number
+    let signal = match panda_abi::Signal::from_u32(signal) {
+        Some(s) => s,
+        None => {
+            return Box::pin(core::future::ready(SyscallResult::err(
+                panda_abi::ErrorCode::InvalidArgument,
+            )))
+        }
+    };
+
+    // 2. Get target process resource from handle
+    let resource = scheduler::with_current_process(|proc| {
+        let handle = proc.handles().get(handle_id)?;
+        if handle.as_process().is_some() {
+            Some(handle.resource_arc())
+        } else {
+            None
+        }
+    });
+
+    let Some(resource) = resource else {
+        return Box::pin(core::future::ready(SyscallResult::err(
+            panda_abi::ErrorCode::InvalidHandle,
+        )));
+    };
+    let Some(process_iface) = resource.as_process() else {
+        return Box::pin(core::future::ready(SyscallResult::err(
+            panda_abi::ErrorCode::InvalidHandle,
+        )));
+    };
+
+    let result = match process_iface.signal(signal.as_u32()) {
+        Ok(()) => SyscallResult::ok(0),
+        Err(crate::resource::ProcessError::NotSupported) => {
+            SyscallResult::err(panda_abi::ErrorCode::NotSupported)
+        }
+        Err(crate::resource::ProcessError::NotFound) => {
+            SyscallResult::err(panda_abi::ErrorCode::NotFound)
+        }
+        Err(crate::resource::ProcessError::PermissionDenied) => {
+            SyscallResult::err(panda_abi::ErrorCode::PermissionDenied)
+        }
+        Err(crate::resource::ProcessError::WouldBlock) => {
+            SyscallResult::err(panda_abi::ErrorCode::WouldBlock)
+        }
+    };
+
+    Box::pin(core::future::ready(result))
 }
 
 /// Handle process brk operation.

--- a/panda-kernel/tests/signal.rs
+++ b/panda-kernel/tests/signal.rs
@@ -1,0 +1,179 @@
+//! Tests for signal encoding/decoding round-trip.
+
+#![no_std]
+#![no_main]
+
+use panda_abi::{
+    ProcessMessageType, Signal, SignalMessage, SIGNAL_MESSAGE_SIZE, encode_signal_message,
+};
+
+panda_kernel::test_harness!(
+    signal_enum_from_u32_valid,
+    signal_enum_from_u32_invalid,
+    encode_signal_message_terminate,
+    encode_signal_message_kill,
+    encode_signal_message_buffer_too_small,
+    decode_signal_message_terminate,
+    decode_signal_message_kill,
+    decode_signal_message_round_trip_terminate,
+    decode_signal_message_round_trip_kill,
+    decode_signal_message_not_signal,
+    decode_signal_message_truncated,
+    decode_signal_message_invalid_signal,
+    is_signal_message_check,
+);
+
+/// Test Signal::from_u32 with valid values.
+fn signal_enum_from_u32_valid() {
+    assert_eq!(Signal::from_u32(0), Some(Signal::Terminate));
+    assert_eq!(Signal::from_u32(1), Some(Signal::Kill));
+}
+
+/// Test Signal::from_u32 with invalid values.
+fn signal_enum_from_u32_invalid() {
+    assert_eq!(Signal::from_u32(2), None);
+    assert_eq!(Signal::from_u32(100), None);
+    assert_eq!(Signal::from_u32(u32::MAX), None);
+}
+
+/// Test encoding a Terminate signal message.
+fn encode_signal_message_terminate() {
+    let mut buf = [0u8; SIGNAL_MESSAGE_SIZE];
+    let len = encode_signal_message(Signal::Terminate, &mut buf);
+
+    assert_eq!(len, Some(SIGNAL_MESSAGE_SIZE));
+
+    // Verify header fields (little-endian)
+    // id (u64) = 0
+    assert_eq!(&buf[0..8], &[0, 0, 0, 0, 0, 0, 0, 0]);
+    // msg_type (u32) = ProcessMessageType::Signal = 1
+    assert_eq!(&buf[8..12], &[1, 0, 0, 0]);
+    // _reserved (u32) = 0
+    assert_eq!(&buf[12..16], &[0, 0, 0, 0]);
+    // signal (u32) = Signal::Terminate = 0
+    assert_eq!(&buf[16..20], &[0, 0, 0, 0]);
+    // _pad (u32) = 0
+    assert_eq!(&buf[20..24], &[0, 0, 0, 0]);
+}
+
+/// Test encoding a Kill signal message.
+fn encode_signal_message_kill() {
+    let mut buf = [0u8; SIGNAL_MESSAGE_SIZE];
+    let len = encode_signal_message(Signal::Kill, &mut buf);
+
+    assert_eq!(len, Some(SIGNAL_MESSAGE_SIZE));
+
+    // signal (u32) = Signal::Kill = 1 at offset 16
+    assert_eq!(&buf[16..20], &[1, 0, 0, 0]);
+}
+
+/// Test encoding fails with buffer too small.
+fn encode_signal_message_buffer_too_small() {
+    let mut buf = [0u8; 10]; // Too small
+    let len = encode_signal_message(Signal::Terminate, &mut buf);
+    assert_eq!(len, None);
+}
+
+/// Test decoding a Terminate signal message.
+fn decode_signal_message_terminate() {
+    let mut buf = [0u8; SIGNAL_MESSAGE_SIZE];
+    encode_signal_message(Signal::Terminate, &mut buf).unwrap();
+
+    let msg = SignalMessage::decode(&buf).unwrap();
+    assert!(msg.is_some());
+    let msg = msg.unwrap();
+    assert_eq!(msg.id, 0);
+    assert_eq!(msg.signal, Signal::Terminate);
+}
+
+/// Test decoding a Kill signal message.
+fn decode_signal_message_kill() {
+    let mut buf = [0u8; SIGNAL_MESSAGE_SIZE];
+    encode_signal_message(Signal::Kill, &mut buf).unwrap();
+
+    let msg = SignalMessage::decode(&buf).unwrap();
+    assert!(msg.is_some());
+    let msg = msg.unwrap();
+    assert_eq!(msg.id, 0);
+    assert_eq!(msg.signal, Signal::Kill);
+}
+
+/// Test round-trip encode/decode for Terminate.
+fn decode_signal_message_round_trip_terminate() {
+    let original = Signal::Terminate;
+    let mut buf = [0u8; SIGNAL_MESSAGE_SIZE];
+    encode_signal_message(original, &mut buf).unwrap();
+
+    let decoded = SignalMessage::decode(&buf).unwrap().unwrap();
+    assert_eq!(decoded.signal, original);
+}
+
+/// Test round-trip encode/decode for Kill.
+fn decode_signal_message_round_trip_kill() {
+    let original = Signal::Kill;
+    let mut buf = [0u8; SIGNAL_MESSAGE_SIZE];
+    encode_signal_message(original, &mut buf).unwrap();
+
+    let decoded = SignalMessage::decode(&buf).unwrap().unwrap();
+    assert_eq!(decoded.signal, original);
+}
+
+/// Test decoding a non-signal message returns None.
+fn decode_signal_message_not_signal() {
+    // Encode a message with a different msg_type
+    let mut buf = [0u8; SIGNAL_MESSAGE_SIZE];
+    // id (u64) = 0
+    buf[0..8].copy_from_slice(&0u64.to_le_bytes());
+    // msg_type (u32) = ProcessMessageType::GetStatus = 0 (not Signal)
+    buf[8..12].copy_from_slice(&(ProcessMessageType::GetStatus as u32).to_le_bytes());
+    // _reserved (u32) = 0
+    buf[12..16].copy_from_slice(&0u32.to_le_bytes());
+    // signal (u32) = 0
+    buf[16..20].copy_from_slice(&0u32.to_le_bytes());
+    // _pad (u32) = 0
+    buf[20..24].copy_from_slice(&0u32.to_le_bytes());
+
+    let msg = SignalMessage::decode(&buf).unwrap();
+    assert!(msg.is_none(), "Should return None for non-signal message");
+}
+
+/// Test decoding a truncated buffer returns error.
+fn decode_signal_message_truncated() {
+    let buf = [0u8; 10]; // Too short
+    let result = SignalMessage::decode(&buf);
+    assert!(result.is_err(), "Should return error for truncated buffer");
+}
+
+/// Test decoding a message with invalid signal value returns error.
+fn decode_signal_message_invalid_signal() {
+    let mut buf = [0u8; SIGNAL_MESSAGE_SIZE];
+    // id (u64) = 0
+    buf[0..8].copy_from_slice(&0u64.to_le_bytes());
+    // msg_type (u32) = ProcessMessageType::Signal = 1
+    buf[8..12].copy_from_slice(&(ProcessMessageType::Signal as u32).to_le_bytes());
+    // _reserved (u32) = 0
+    buf[12..16].copy_from_slice(&0u32.to_le_bytes());
+    // signal (u32) = 99 (invalid)
+    buf[16..20].copy_from_slice(&99u32.to_le_bytes());
+    // _pad (u32) = 0
+    buf[20..24].copy_from_slice(&0u32.to_le_bytes());
+
+    let result = SignalMessage::decode(&buf);
+    assert!(result.is_err(), "Should return error for invalid signal value");
+}
+
+/// Test is_signal_message helper.
+fn is_signal_message_check() {
+    // Valid signal message
+    let mut buf = [0u8; SIGNAL_MESSAGE_SIZE];
+    encode_signal_message(Signal::Terminate, &mut buf).unwrap();
+    assert!(SignalMessage::is_signal_message(&buf));
+
+    // Non-signal message
+    buf[8..12].copy_from_slice(&(ProcessMessageType::GetStatus as u32).to_le_bytes());
+    assert!(!SignalMessage::is_signal_message(&buf));
+
+    // Buffer too short
+    let short_buf = [0u8; 10];
+    assert!(!SignalMessage::is_signal_message(&short_buf));
+}

--- a/userspace/libpanda/src/mailbox.rs
+++ b/userspace/libpanda/src/mailbox.rs
@@ -116,6 +116,12 @@ impl Events {
         self.0 & EVENT_PROCESS_EXITED != 0
     }
 
+    /// Check if a signal was received.
+    #[inline(always)]
+    pub fn is_signal_received(&self) -> bool {
+        self.0 & EVENT_SIGNAL_RECEIVED != 0
+    }
+
     /// Iterate over all set events.
     ///
     /// This yields each event that is set in the flags.

--- a/userspace/libpanda/src/process/child.rs
+++ b/userspace/libpanda/src/process/child.rs
@@ -95,9 +95,9 @@ impl Child {
         }
     }
 
-    /// Kill the child process (send SIGKILL equivalent).
+    /// Stop the child process immediately (send SIGKILL equivalent).
     pub fn kill(&mut self) -> Result<()> {
-        self.signal(Signal::Kill)
+        self.signal(Signal::StopImmediately)
     }
 
     /// Consume the Child and return the underlying handle without waiting.
@@ -326,8 +326,8 @@ impl ExitStatus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum Signal {
-    /// Terminate the process gracefully.
-    Term = 0,
-    /// Kill the process immediately.
-    Kill = 1,
+    /// Request graceful termination.
+    Stop = 0,
+    /// Stop the process immediately.
+    StopImmediately = 1,
 }

--- a/userspace/libpanda/src/process/mod.rs
+++ b/userspace/libpanda/src/process/mod.rs
@@ -17,7 +17,7 @@
 
 mod child;
 
-pub use child::{Child, ChildBuilder, ExitStatus};
+pub use child::{Child, ChildBuilder, ExitStatus, Signal};
 
 use crate::Handle;
 use crate::sys;

--- a/userspace/tests/signal_child/Cargo.toml
+++ b/userspace/tests/signal_child/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "signal_child"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+libpanda = { path = "../../libpanda" }
+panda-abi = { path = "../../../panda-abi" }

--- a/userspace/tests/signal_child/src/main.rs
+++ b/userspace/tests/signal_child/src/main.rs
@@ -1,0 +1,75 @@
+//! Signal child - a helper process that handles signals gracefully.
+//!
+//! This process loops until it receives a SIGTERM signal on HANDLE_PARENT,
+//! then exits gracefully with code 0.
+
+#![no_std]
+#![no_main]
+
+use libpanda::{environment, mailbox::Mailbox};
+use panda_abi::{SignalMessage, Signal, SIGNAL_MESSAGE_SIZE, HANDLE_PARENT};
+
+libpanda::main! {
+    environment::log("Signal child: starting event loop");
+
+    // Get the default mailbox
+    let mailbox = Mailbox::default();
+    let parent_handle = libpanda::handle::Handle::from(HANDLE_PARENT);
+
+    // Loop until we receive SIGTERM
+    loop {
+        // Poll the mailbox for events (non-blocking with timeout via yield)
+        if let Some((handle, events)) = mailbox.try_recv() {
+            // Check if this is a signal on the parent channel
+            if handle == parent_handle && events.is_signal_received() {
+                environment::log("Signal child: received signal event");
+
+                // Try to receive the signal message (non-blocking)
+                let mut buf = [0u8; SIGNAL_MESSAGE_SIZE];
+                let result = libpanda::sys::channel::try_recv_msg(
+                    parent_handle,
+                    &mut buf
+                );
+
+                if result >= SIGNAL_MESSAGE_SIZE as isize {
+                    let len = result as usize;
+                    // Decode the signal message
+                    match SignalMessage::decode(&buf[..len]) {
+                        Ok(Some(msg)) => {
+                            environment::log("Signal child: decoded signal message");
+                            match msg.signal {
+                                Signal::Terminate => {
+                                    environment::log("Signal child: SIGTERM received, exiting gracefully");
+                                    return 0; // Clean exit
+                                }
+                                Signal::Kill => {
+                                    // We shouldn't receive SIGKILL as a message
+                                    // (it's handled by the kernel immediately)
+                                    environment::log("Signal child: unexpected SIGKILL message");
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            environment::log("Signal child: not a signal message");
+                        }
+                        Err(_) => {
+                            environment::log("Signal child: failed to decode signal");
+                        }
+                    }
+                } else if result > 0 {
+                    environment::log("Signal child: message too short");
+                }
+                // Negative result means error (e.g., queue empty), which is fine
+            }
+
+            // Check for channel close (parent died)
+            if handle == parent_handle && events.is_channel_closed() {
+                environment::log("Signal child: parent closed channel, exiting");
+                return 1;
+            }
+        }
+
+        // Yield to allow other processes to run
+        libpanda::process::yield_now();
+    }
+}

--- a/userspace/tests/signal_child/src/main.rs
+++ b/userspace/tests/signal_child/src/main.rs
@@ -33,7 +33,13 @@ libpanda::main! {
 
                 if result >= SIGNAL_MESSAGE_SIZE as isize {
                     let len = result as usize;
-                    // Decode the signal message
+                    // First check the message header to see if this is a signal message
+                    if !SignalMessage::is_signal_message(&buf[..len]) {
+                        environment::log("Signal child: not a signal message");
+                        continue;
+                    }
+
+                    // Now decode the signal message payload
                     match SignalMessage::decode(&buf[..len]) {
                         Ok(Some(msg)) => {
                             environment::log("Signal child: decoded signal message");
@@ -50,7 +56,8 @@ libpanda::main! {
                             }
                         }
                         Ok(None) => {
-                            environment::log("Signal child: not a signal message");
+                            // This shouldn't happen since we checked is_signal_message above
+                            environment::log("Signal child: unexpected decode result");
                         }
                         Err(_) => {
                             environment::log("Signal child: failed to decode signal");

--- a/userspace/tests/signal_child/src/main.rs
+++ b/userspace/tests/signal_child/src/main.rs
@@ -38,14 +38,14 @@ libpanda::main! {
                         Ok(Some(msg)) => {
                             environment::log("Signal child: decoded signal message");
                             match msg.signal {
-                                Signal::Terminate => {
-                                    environment::log("Signal child: SIGTERM received, exiting gracefully");
+                                Signal::Stop => {
+                                    environment::log("Signal child: stop signal received, exiting gracefully");
                                     return 0; // Clean exit
                                 }
-                                Signal::Kill => {
-                                    // We shouldn't receive SIGKILL as a message
+                                Signal::StopImmediately => {
+                                    // We shouldn't receive StopImmediately as a message
                                     // (it's handled by the kernel immediately)
-                                    environment::log("Signal child: unexpected SIGKILL message");
+                                    environment::log("Signal child: unexpected StopImmediately message");
                                 }
                             }
                         }
@@ -58,8 +58,11 @@ libpanda::main! {
                     }
                 } else if result > 0 {
                     environment::log("Signal child: message too short");
+                } else {
+                    // Negative result means an error occurred (e.g., WouldBlock if queue is empty).
+                    // This can happen if the signal was consumed by another call or a race occurred.
+                    environment::log("Signal child: no message available");
                 }
-                // Negative result means error (e.g., queue empty), which is fine
             }
 
             // Check for channel close (parent died)

--- a/userspace/tests/signal_test/Cargo.toml
+++ b/userspace/tests/signal_test/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "signal_test"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+libpanda = { path = "../../libpanda" }
+panda-abi = { path = "../../../panda-abi" }

--- a/userspace/tests/signal_test/expected.txt
+++ b/userspace/tests/signal_test/expected.txt
@@ -1,0 +1,16 @@
+# @unordered
+Signal test: starting
+Test 1: SIGKILL
+# @barrier
+Signal child: starting event loop
+Test 1: PASS
+Test 2: SIGTERM
+# @barrier
+Signal child: starting event loop
+Signal child: received signal event
+Signal child: decoded signal message
+Signal child: stop signal received, exiting gracefully
+Test 2: PASS
+# @barrier
+Signal test: all tests passed
+PASS

--- a/userspace/tests/signal_test/expected.txt
+++ b/userspace/tests/signal_test/expected.txt
@@ -1,10 +1,10 @@
 # @unordered
 Signal test: starting
-Test 1: SIGKILL
+Test 1: StopImmediately
 # @barrier
 Signal child: starting event loop
 Test 1: PASS
-Test 2: SIGTERM
+Test 2: Stop
 # @barrier
 Signal child: starting event loop
 Signal child: received signal event

--- a/userspace/tests/signal_test/src/main.rs
+++ b/userspace/tests/signal_test/src/main.rs
@@ -1,4 +1,4 @@
-//! Signal test - tests SIGKILL and SIGTERM signal delivery.
+//! Signal test - tests StopImmediately and Stop signal delivery.
 
 #![no_std]
 #![no_main]
@@ -8,17 +8,17 @@ use libpanda::{environment, process::Child};
 libpanda::main! {
     environment::log("Signal test: starting");
 
-    // Test 1: SIGKILL a looping child
-    environment::log("Test 1: SIGKILL");
-    if !test_sigkill() {
+    // Test 1: StopImmediately a looping child
+    environment::log("Test 1: StopImmediately");
+    if !test_stop_immediately() {
         environment::log("FAIL: Test 1 failed");
         return 1;
     }
     environment::log("Test 1: PASS");
 
-    // Test 2: SIGTERM with graceful handling
-    environment::log("Test 2: SIGTERM");
-    if !test_sigterm() {
+    // Test 2: Stop with graceful handling
+    environment::log("Test 2: Stop");
+    if !test_stop() {
         environment::log("FAIL: Test 2 failed");
         return 1;
     }
@@ -29,12 +29,12 @@ libpanda::main! {
     0
 }
 
-/// Test SIGKILL: spawn a child, kill it, verify termination with exit code -9.
-fn test_sigkill() -> bool {
+/// Test StopImmediately: spawn a child, kill it, verify termination with exit code -9.
+fn test_stop_immediately() -> bool {
     let mut child = match Child::spawn("file:/initrd/signal_child") {
         Ok(c) => c,
         Err(_) => {
-            environment::log("  SIGKILL: spawn failed");
+            environment::log("  StopImmediately: spawn failed");
             return false;
         }
     };
@@ -44,9 +44,9 @@ fn test_sigkill() -> bool {
         libpanda::process::yield_now();
     }
 
-    // Send SIGKILL
+    // Send StopImmediately
     if let Err(_) = child.kill() {
-        environment::log("  SIGKILL: kill() failed");
+        environment::log("  StopImmediately: kill() failed");
         return false;
     }
 
@@ -54,28 +54,28 @@ fn test_sigkill() -> bool {
     let status = match child.wait() {
         Ok(s) => s,
         Err(_) => {
-            environment::log("  SIGKILL: wait() failed");
+            environment::log("  StopImmediately: wait() failed");
             return false;
         }
     };
 
     // Verify exit code is -9 (killed by signal)
     if status.code() != -9 {
-        environment::log("  SIGKILL: wrong exit code (expected -9)");
+        environment::log("  StopImmediately: wrong exit code (expected -9)");
         return false;
     }
 
     true
 }
 
-/// Test SIGTERM: spawn a child that handles SIGTERM gracefully.
-fn test_sigterm() -> bool {
+/// Test Stop: spawn a child that handles Stop gracefully.
+fn test_stop() -> bool {
     use libpanda::process::Signal;
 
     let mut child = match Child::spawn("file:/initrd/signal_child") {
         Ok(c) => c,
         Err(_) => {
-            environment::log("  SIGTERM: spawn failed");
+            environment::log("  Stop: spawn failed");
             return false;
         }
     };
@@ -85,9 +85,9 @@ fn test_sigterm() -> bool {
         libpanda::process::yield_now();
     }
 
-    // Send SIGTERM
-    if let Err(_) = child.signal(Signal::Term) {
-        environment::log("  SIGTERM: signal() failed");
+    // Send Stop
+    if let Err(_) = child.signal(Signal::Stop) {
+        environment::log("  Stop: signal() failed");
         return false;
     }
 
@@ -95,14 +95,14 @@ fn test_sigterm() -> bool {
     let status = match child.wait() {
         Ok(s) => s,
         Err(_) => {
-            environment::log("  SIGTERM: wait() failed");
+            environment::log("  Stop: wait() failed");
             return false;
         }
     };
 
     // Verify clean exit (code 0 indicates graceful shutdown)
     if status.code() != 0 {
-        environment::log("  SIGTERM: wrong exit code (expected 0)");
+        environment::log("  Stop: wrong exit code (expected 0)");
         return false;
     }
 

--- a/userspace/tests/signal_test/src/main.rs
+++ b/userspace/tests/signal_test/src/main.rs
@@ -1,0 +1,110 @@
+//! Signal test - tests SIGKILL and SIGTERM signal delivery.
+
+#![no_std]
+#![no_main]
+
+use libpanda::{environment, process::Child};
+
+libpanda::main! {
+    environment::log("Signal test: starting");
+
+    // Test 1: SIGKILL a looping child
+    environment::log("Test 1: SIGKILL");
+    if !test_sigkill() {
+        environment::log("FAIL: Test 1 failed");
+        return 1;
+    }
+    environment::log("Test 1: PASS");
+
+    // Test 2: SIGTERM with graceful handling
+    environment::log("Test 2: SIGTERM");
+    if !test_sigterm() {
+        environment::log("FAIL: Test 2 failed");
+        return 1;
+    }
+    environment::log("Test 2: PASS");
+
+    environment::log("Signal test: all tests passed");
+    environment::log("PASS");
+    0
+}
+
+/// Test SIGKILL: spawn a child, kill it, verify termination with exit code -9.
+fn test_sigkill() -> bool {
+    let mut child = match Child::spawn("file:/initrd/signal_child") {
+        Ok(c) => c,
+        Err(_) => {
+            environment::log("  SIGKILL: spawn failed");
+            return false;
+        }
+    };
+
+    // Give child a moment to start
+    for _ in 0..100 {
+        libpanda::process::yield_now();
+    }
+
+    // Send SIGKILL
+    if let Err(_) = child.kill() {
+        environment::log("  SIGKILL: kill() failed");
+        return false;
+    }
+
+    // Wait for child
+    let status = match child.wait() {
+        Ok(s) => s,
+        Err(_) => {
+            environment::log("  SIGKILL: wait() failed");
+            return false;
+        }
+    };
+
+    // Verify exit code is -9 (killed by signal)
+    if status.code() != -9 {
+        environment::log("  SIGKILL: wrong exit code (expected -9)");
+        return false;
+    }
+
+    true
+}
+
+/// Test SIGTERM: spawn a child that handles SIGTERM gracefully.
+fn test_sigterm() -> bool {
+    use libpanda::process::Signal;
+
+    let mut child = match Child::spawn("file:/initrd/signal_child") {
+        Ok(c) => c,
+        Err(_) => {
+            environment::log("  SIGTERM: spawn failed");
+            return false;
+        }
+    };
+
+    // Give child a moment to start
+    for _ in 0..100 {
+        libpanda::process::yield_now();
+    }
+
+    // Send SIGTERM
+    if let Err(_) = child.signal(Signal::Term) {
+        environment::log("  SIGTERM: signal() failed");
+        return false;
+    }
+
+    // Wait for child to handle it gracefully
+    let status = match child.wait() {
+        Ok(s) => s,
+        Err(_) => {
+            environment::log("  SIGTERM: wait() failed");
+            return false;
+        }
+    };
+
+    // Verify clean exit (code 0 indicates graceful shutdown)
+    if status.code() != 0 {
+        environment::log("  SIGTERM: wrong exit code (expected 0)");
+        return false;
+    }
+
+    true
+}


### PR DESCRIPTION
## Summary

Implement `OP_PROCESS_SIGNAL` for SIGKILL and SIGTERM signal delivery.

- **SIGKILL**: Kernel immediately tears down the target process
- **SIGTERM**: Delivered as a message on `HANDLE_PARENT` channel

Closes #27
Part of #26

Generated with [Claude Code](https://claude.ai/claude-code)